### PR TITLE
Replace champions section with administration profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,56 +713,59 @@
         </div>
       </div>
 
-      <!-- Administration Section -->
-      <section class="bg-black py-20 sm:py-28" id="administration-section">
-        <div class="mx-auto max-w-7xl px-6 lg:px-8">
-          <!-- top divider -->
-          <div class="section-divider mb-8" aria-hidden="true"></div>
+<!-- Administration Section -->
+<section class="bg-black py-20 sm:py-28" id="administration-section">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <!-- top divider -->
+    <div class="section-divider mb-8" aria-hidden="true"></div>
 
-          <div class="flex items-end justify-between flex-wrap gap-3 mb-6">
-            <div>
-              <h2
-                class="text-4xl sm:text-5xl font-semibold tracking-tight text-white text-glow"
-              >
-                Meet Our Administration
-              </h2>
-            </div>
-          </div>
+    <div class="flex items-end justify-between flex-wrap gap-3 mb-10">
+      <div>
+        <h2
+          class="text-4xl sm:text-5xl font-semibold tracking-tight text-white text-glow"
+        >
+          Meet Our Administration
+        </h2>
+      </div>
+    </div>
 
-          <div
-            class="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8"
-            id="admin-profiles"
-          >
-            <!-- TripleU -->
-            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
-              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
-                <img src="INSERT_LINK" alt="@TripleU avatar" />
-              </div>
-              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
-              <div class="font-bold text-white mt-2">@TripleU</div>
-              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
-            </div>
+    <div
+      class="grid grid-cols-1 md:grid-cols-3 gap-8 lg:gap-10"
+      id="admin-profiles"
+    >
+      <!-- Ushy Weiss -->
+      <div class="bg-gray-900 rounded-xl shadow-lg p-8 text-center">
+        <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+          <img src="https://forums.jtechforums.org/user_avatar/forums.jtechforums.org/tripleu/144/488_2.png" alt="@TripleU avatar" />
+        </div>
+        <h3 class="font-bold text-2xl text-white mt-4">Ushy Weiss</h3>
+        <div class="text-sm text-gray-400 mt-1">@TripleU</div>
+        <p class="mt-3 text-sm text-gray-300">Forums Owner & Maintainer</p>
+      </div>
 
-            <!-- ars18 -->
-            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
-              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
-                <img src="INSERT_LINK" alt="@ars18 avatar" />
-              </div>
-              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
-              <div class="font-bold text-white mt-2">@ars18</div>
-              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
-            </div>
+      <!-- Avrumi Sternheim -->
+      <div class="bg-gray-900 rounded-xl shadow-lg p-8 text-center">
+        <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+          <img src="https://forums.jtechforums.org/user_avatar/forums.jtechforums.org/ars18/144/2336_2.png" alt="@ars18 avatar" />
+        </div>
+        <h3 class="font-bold text-2xl text-white mt-4">Avrumi Sternheim</h3>
+        <div class="text-sm text-gray-400 mt-1">@ars18</div>
+        <p class="mt-3 text-sm text-gray-300">Forums Admin & Moderator</p>
+      </div>
 
-            <!-- flipadmin -->
-            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
-              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
-                <img src="INSERT_LINK" alt="@flipadmin avatar" />
-              </div>
-              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
-              <div class="font-bold text-white mt-2">@flipadmin</div>
-              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
-            </div>
-          </div>
+      <!-- Offline software solutions -->
+      <div class="bg-gray-900 rounded-xl shadow-lg p-8 text-center">
+        <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+          <img src="https://forums.jtechforums.org/user_avatar/forums.jtechforums.org/flipadmin/144/2891_2.png" alt="@flipadmin avatar" />
+        </div>
+        <h3 class="font-bold text-2xl text-white mt-4">Offline software solutions</h3>
+        <div class="text-sm text-gray-400 mt-1">@flipadmin</div>
+        <p class="mt-3 text-sm text-gray-300">Forum Founder & Developer</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 
           <!-- bottom divider -->
           <div class="section-divider mt-10" aria-hidden="true"></div>

--- a/index.html
+++ b/index.html
@@ -713,8 +713,8 @@
         </div>
       </div>
 
-      <!-- Champions Section -->
-      <section class="bg-black py-20 sm:py-28" id="champions-section">
+      <!-- Administration Section -->
+      <section class="bg-black py-20 sm:py-28" id="administration-section">
         <div class="mx-auto max-w-7xl px-6 lg:px-8">
           <!-- top divider -->
           <div class="section-divider mb-8" aria-hidden="true"></div>
@@ -724,23 +724,45 @@
               <h2
                 class="text-4xl sm:text-5xl font-semibold tracking-tight text-white text-glow"
               >
-                JTech Champions — Top 5
+                Meet Our Administration
               </h2>
-              <p class="mt-2 text-sm font-semibold text-blue-300/90">
-                from this month
-              </p>
             </div>
           </div>
 
-          <!-- a little more breathing room + larger gaps -->
           <div
-            class="podium grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8"
-            id="podium-champions"
-          ></div>
-          <div
-            class="top5 grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8 mt-8"
-            id="top5-champions"
-          ></div>
+            class="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8"
+            id="admin-profiles"
+          >
+            <!-- TripleU -->
+            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
+              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+                <img src="INSERT_LINK" alt="@TripleU avatar" />
+              </div>
+              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
+              <div class="font-bold text-white mt-2">@TripleU</div>
+              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
+            </div>
+
+            <!-- ars18 -->
+            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
+              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+                <img src="INSERT_LINK" alt="@ars18 avatar" />
+              </div>
+              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
+              <div class="font-bold text-white mt-2">@ars18</div>
+              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
+            </div>
+
+            <!-- flipadmin -->
+            <div class="bg-gray-900 rounded-xl shadow-lg p-6 text-center">
+              <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 outline-gray-700 mx-auto">
+                <img src="INSERT_LINK" alt="@flipadmin avatar" />
+              </div>
+              <a href="INSERT_LINK" class="text-blue-400 text-sm mt-2 block">Insert link</a>
+              <div class="font-bold text-white mt-2">@flipadmin</div>
+              <p class="mt-2 text-sm text-gray-300">TODO: description</p>
+            </div>
+          </div>
 
           <!-- bottom divider -->
           <div class="section-divider mt-10" aria-hidden="true"></div>
@@ -1809,92 +1831,6 @@
           });
         }
 
-        /* ---------------- Champions ---------------- */
-        const podiumEl = document.getElementById("podium-champions");
-        const top5El = document.getElementById("top5-champions");
-
-        const crownPath =
-          "M3 7l4.5 3 4.5-6 4.5 6L21 7v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z";
-        const mkSvg = (vb, d) => {
-          const el = document.createElementNS(
-            "http://www.w3.org/2000/svg",
-            "svg",
-          );
-          el.setAttribute("viewBox", vb);
-          el.setAttribute("fill", "currentColor");
-          el.innerHTML = `<path d="${d}"></path>`;
-          return el;
-        };
-
-        function podiumCard(item, index) {
-          const ringClass =
-            index === 0
-              ? "outline-yellow-500"
-              : index === 1
-                ? "outline-gray-400"
-                : "outline-amber-700";
-          const card = document.createElement("div");
-          card.className =
-            "relative bg-gray-900 rounded-xl shadow-lg outline outline-1 outline-gray-700 p-4 flex flex-col items-center text-center";
-          card.innerHTML = `
-            <div class="w-24 h-24 rounded-full overflow-hidden outline outline-2 ${ringClass} mb-3">
-              ${
-                item.avatar
-                  ? `<img src="${item.avatar}" alt="${item.name}" onerror="this.remove()">`
-                  : ""
-              }
-            </div>
-            <div class="font-bold text-white">${item.name}</div>
-            <div class="text-blue-300 font-bold flex items-center gap-1">${item.score.toLocaleString()} ${mkSvg(
-              "0 0 24 24",
-              crownPath,
-            ).outerHTML}</div>`;
-          return card;
-        }
-
-        function miniCard(item, rank) {
-          const el = document.createElement("div");
-          el.className =
-            "flex items-center gap-3 bg-gray-900 p-3 rounded-lg shadow-md outline outline-1 outline-gray-700";
-          el.innerHTML = `
-            <div class="w-8 h-8 rounded-md flex items-center justify-center font-extrabold bg-gray-800 text-white outline outline-2 outline-gray-700">${rank}</div>
-            <div class="w-14 h-14 rounded-md overflow-hidden bg-gray-800">
-              ${
-                item.avatar
-                  ? `<img src="${item.avatar}" alt="${item.name}" onerror="this.remove()">`
-                  : ""
-              }
-            </div>
-            <div class="flex-1">
-              <div class="font-bold text-white">${item.name}</div>
-              <div class="text-gray-400 font-bold">${item.score.toLocaleString()}</div>
-            </div>`;
-          return el;
-        }
-
-        function renderChampions(list) {
-          if (!podiumEl || !top5El || !list.length) return;
-          list.slice(0, 3).forEach((p, i) =>
-            podiumEl.appendChild(podiumCard(p, i)),
-          );
-          list.slice(3, 5).forEach((p, i) =>
-            top5El.appendChild(miniCard(p, i + 4)),
-          );
-        }
-
-        fetch(
-          "https://forums.jtechforums.org/api/users?sort=-points&page[limit]=5",
-        )
-          .then((r) => r.json())
-          .then((json) => {
-            const champs = (json.data || []).map((u) => ({
-              name: u.attributes.username,
-              score: u.attributes.points || 0,
-              avatar: u.attributes.avatarUrl,
-            }));
-            renderChampions(champs);
-          })
-          .catch(() => {});
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- replace "JTech Champions" leaderboard with professional "Meet Our Administration" section
- add placeholder cards for @TripleU, @ars18, and @flipadmin with link and description fields
- remove JavaScript that fetched and rendered champion data

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bc1d3324832596c9e0e207e4f993