### PR TITLE
Replace Typeform contact form with mailto form

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -51,12 +51,16 @@
       <div
         class="relative isolate overflow-hidden bg-gray-900 px-6 py-6 shadow-2xl sm:rounded-3xl sm:px-6"
       >
+        <!-- ✅ Using FormSubmit instead of mailto -->
         <form
-          action="mailto:tripleuworld@gmail.com"
+          action="https://formsubmit.co/tripleuworld@gmail.com"
           method="POST"
-          enctype="text/plain"
           class="space-y-6"
         >
+          <!-- Prevent spam -->
+          <input type="hidden" name="_captcha" value="false" />
+          <input type="hidden" name="_next" value="https://jtechforums.org/thank-you.html" />
+
           <div>
             <label
               for="name"

--- a/contact-us.html
+++ b/contact-us.html
@@ -51,8 +51,75 @@
       <div
         class="relative isolate overflow-hidden bg-gray-900 px-6 py-6 shadow-2xl sm:rounded-3xl sm:px-6"
       >
-        <div data-tf-live="01JT95Z7AZPPGGQ9E1PMGASQME"></div>
-        <script src="//embed.typeform.com/next/embed.js"></script>
+        <form
+          action="mailto:tripleuworld@gmail.com"
+          method="POST"
+          enctype="text/plain"
+          class="space-y-6"
+        >
+          <div>
+            <label
+              for="name"
+              class="block text-sm font-medium text-gray-300"
+              >Name</label
+            >
+            <input
+              type="text"
+              id="name"
+              name="name"
+              required
+              class="mt-1 w-full rounded-md border-gray-700 bg-gray-800 text-white focus:border-blue-500 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              for="phone"
+              class="block text-sm font-medium text-gray-300"
+              >Phone Number</label
+            >
+            <input
+              type="tel"
+              id="phone"
+              name="phone"
+              required
+              class="mt-1 w-full rounded-md border-gray-700 bg-gray-800 text-white focus:border-blue-500 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              for="email"
+              class="block text-sm font-medium text-gray-300"
+              >Email</label
+            >
+            <input
+              type="email"
+              id="email"
+              name="email"
+              required
+              class="mt-1 w-full rounded-md border-gray-700 bg-gray-800 text-white focus:border-blue-500 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              for="message"
+              class="block text-sm font-medium text-gray-300"
+              >Message</label
+            >
+            <textarea
+              id="message"
+              name="message"
+              rows="4"
+              required
+              class="mt-1 w-full rounded-md border-gray-700 bg-gray-800 text-white focus:border-blue-500 focus:ring-blue-500"
+            ></textarea>
+          </div>
+          <button
+            type="submit"
+            class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Send
+          </button>
+        </form>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove Typeform embed on contact page
- add simple email contact form forwarding to tripleuworld@gmail.com

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b3c5f9536883258d5dd82ce4848da2